### PR TITLE
Avoid importing chinese_whispers to source version/license

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,25 @@
+import codecs
+import os.path
+
 from setuptools import setup
 
-from chinese_whispers import __version__, __license__
+def read(rel_path):
+    here = os.path.abspath(os.path.dirname(__file__))
+    with codecs.open(os.path.join(here, rel_path), 'r') as fp:
+        return fp.read()
+
+def get_package_var(name, rel_path):
+    for line in read(rel_path).splitlines():
+        if line.startswith(name):
+            delim = '"' if '"' in line else "'"
+            return line.split(delim)[1]
+    else:
+        raise RuntimeError("Unable to find version string.")
+
+init_path = "chinese_whispers/__init__.py"
+
+__version__ = get_package_var("__version__", init_path)
+__license__ = get_package_var("__license__", init_path)
 
 with open('README.md', 'r', encoding='UTF-8') as f:
     long_description = f.read()


### PR DESCRIPTION
In order to single-source the version and license information, setup.py imported the chinese_whispers package.  However, if installed as a library, the networkx package is not yet available, and this causes `pip install` to fail.  This can be seen by trying to install chinese_whispers in a fresh python environment:

```
$ pip install chinese_whispers
Collecting chinese_whispers
  Using cached chinese-whispers-0.7.0.tar.gz (4.6 kB)
    ERROR: Command errored out with exit status 1:
     command: <PATH>/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-n50asvj5/chinese-whispers/setup.py'"'"'; __file__='"'"'/tmp/pip-install-n50asvj5/chinese-whispers/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-install-n50asvj5/chinese-whispers/pip-egg-info
         cwd: /tmp/pip-install-n50asvj5/chinese-whispers/
    Complete output (9 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-n50asvj5/chinese-whispers/setup.py", line 3, in <module>
        from chinese_whispers import __version__, __license__
      File "/tmp/pip-install-n50asvj5/chinese-whispers/chinese_whispers/__init__.py", line 6, in <module>
        from .chinese_whispers import WEIGHTING, top_weighting, lin_weighting, log_weighting
      File "/tmp/pip-install-n50asvj5/chinese-whispers/chinese_whispers/chinese_whispers.py", line 10, in <module>
        from networkx.classes import Graph
    ModuleNotFoundError: No module named 'networkx'
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```

By directly reading the `chinese_whispers/__init__.py` file, one can source the package and license information without first needing to import the package.

This is the style of single-sourcing recommended by PyPA (see https://packaging.python.org/guides/single-sourcing-package-version/).